### PR TITLE
Add a daily job to purge expired memory

### DIFF
--- a/memory.js
+++ b/memory.js
@@ -1,13 +1,15 @@
 // Description: Memory class
 // This class is used to store key-value pairs in memory.
 // A super super simple in-memory cache that will get reset if the server ever restarts.
+// Also, it will expire after 3 days if not accessed.
 // DANGER: This is not a good way to store data in production. This is just for learning purposes.
-// The cache doesn't expire, so it would keep growing and growing without handling cleanup.
 const defaultExpiration = 259200000 // 3 days
+const checkExpirationInterval = 86400000 // 1 day
 
 class Memory {
   constructor () {
     this.memory = {}
+    this.startExpirationJob()
   }
 
   get (key) {
@@ -33,6 +35,22 @@ class Memory {
 
   expiration(key) {
     return this.memory[key].expiration
+  }
+  
+  isExpired(key) {
+    return this.memory[key].expiration < Date.now()
+  }
+
+  startExpirationJob() {
+    setInterval(() => this.checkExpirations(), checkExpirationInterval)
+  }
+
+  checkExpirations = () => {
+    for (const key in this.memory) {
+      if (this.isExpired(key)) {
+        this.delete(key)
+      }
+    }
   }
 }
 

--- a/test/memory.test.js
+++ b/test/memory.test.js
@@ -5,8 +5,8 @@ let mem
 
 describe('Memory', () => {
   beforeEach(() => {
-    mem = new Memory()
     jest.clearAllTimers()
+    mem = new Memory()
   })
 
   it('should set and get a value', () => {
@@ -30,12 +30,34 @@ describe('Memory', () => {
       expect(mem.expiration('foo')).toEqual(Date.now() + defaultExpiration)
     })
 
-    it('should renew the expiration time by three days if get is called', () => {
+    it('should renew the expiration time by three days if get() is called', () => {
       mem.set('foo', 'bar')
       const advanceTimeBy = 10000
       jest.advanceTimersByTime(advanceTimeBy)
       mem.get('foo') 
       expect(mem.expiration('foo')).toEqual(Date.now() + defaultExpiration)
+    })
+
+    it('should call checkExpiration every 1 day', () => {
+      const spy = jest.spyOn(mem, 'checkExpirations')
+      jest.advanceTimersByTime(86400000)
+      expect(spy).toHaveBeenCalledTimes(1)
+      jest.advanceTimersByTime(86400000)
+      expect(spy).toHaveBeenCalledTimes(2)
+    })
+
+    it('should deleted the key if expired', () => {
+      mem.set('foo', 'bar')
+      const advanceTimeBy = defaultExpiration + 86400000
+      jest.advanceTimersByTime(advanceTimeBy)
+      expect(mem.get('foo')).toBeNull()
+    })
+
+    it('should not delete the key if not expired', () => {
+      mem.set('foo', 'bar')
+      const advanceTimeBy = defaultExpiration - 86400000
+      jest.advanceTimersByTime(advanceTimeBy)
+      expect(mem.get('foo')).toEqual('bar')
     })
   })
 });


### PR DESCRIPTION
## Description

This change adds a daily job to cleanup the game memory.  🧹  🤸🏻‍♂️ 

### What approach did I choose and why?

Well, this is already a pretty terrible way to store memory.  It's volatile (if the server is restarted or shutdown, all games will be lost).  Because we had no way of cleaning up abandoned games, I decided to add a method that would trigger in a daily interval.  This method would check to see if the game had been abandoned (defined as: not fetched in 3 days from the api) then it gets wiped.

### What to focus on

Is this easy to read and understand?